### PR TITLE
implementing basic routing with browser router

### DIFF
--- a/limedaichatFrontend/src/App.tsx
+++ b/limedaichatFrontend/src/App.tsx
@@ -1,12 +1,17 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import "@/App.css";
 import Auth from "@/pages/authentication";
+import Chat from "@/pages/chat";
 
 const App = () => {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/authentication" element={<Auth />} />
+        {/* TODO: wrap chat and any future routes that needs to be protected in suspense after the Auth is setup */}
+        <Route path="/chat" element={<Chat />} />
+        {/* TODO: add a page not found component with butten to redirect back to auth or chat home page based on if user is authenticated or not */}
+        <Route path="*" element={<Navigate to={"/authentication"} />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
implemented basic routing with browser router for "/authentication" and "/chat" and wildcard route to navigate back to authentication component if an unknown route is tried. added TODOs for implementing page not found component and features for it and wrapping "/chat" and other routes that needs to be protected in the future to be wrapped in suspense once authentication is implemented